### PR TITLE
docs: workaround for installing with yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Make sure you have > node 10 LTS installed. There's currently no `yarn.lock` fil
 $ npm i -g etherscan-uploader
 ```
 
+or with yarn
+
+```
+$ yarn global add etherscan-uploader --ignore-engines
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
By default, yarn checks node engine version and one of the deps (`solidity-flattener`) has engine set to `6.10.1`. To workaround this use the flag `--ignore-engines`.